### PR TITLE
Update FSQTransparentWebView.h

### DIFF
--- a/Source/UIKit/Views/FSQTransparentWebView.h
+++ b/Source/UIKit/Views/FSQTransparentWebView.h
@@ -7,7 +7,8 @@
 //
 
 #import <UIKit/UIKit.h>
+#import <WebKit/WebKit.h>
 
-@interface FSQTransparentWebView : UIWebView
+@interface FSQTransparentWebView : WKWebView
 
 @end


### PR DESCRIPTION
Changed UIWebView to WKWebView.

SevensquareKit needed to do this in order to comply with Apple's deprecation of UIWebView.  I'm not sure if this will work for FivesquareKit customers as the methods in UIWebView might not be supported in WKWebView.  Contact SevensquareKit if you'd like us to investigate this.